### PR TITLE
Add tests and roadmap checklist

### DIFF
--- a/bootstrap.md
+++ b/bootstrap.md
@@ -85,6 +85,20 @@ Total ≈ **14–16 weeks** for a beta on crates.io.
 
 1. Build on top of Taffy and spike the `Size3`.
 
+## Task list
+
+The following checklist tracks the remaining work to reach feature parity with
+`react-three-flex` for the layout engine itself:
+
+- [ ] Generalise the solver to operate over `Size3` and `Point3` in all axes.
+- [ ] Port the Flexbox algorithm to support the new stack (depth) axis.
+- [ ] Implement depth-aware grid and block layout primitives.
+- [ ] Mirror the layout props exposed by `react-three-flex` (flex direction,
+      wrap, gap, alignment, etc.).
+- [ ] Provide adapters that map solved layouts to `Transform` structures in 3‑D
+      engines.
+- [ ] Benchmark and add caching to ensure performance parity with 2‑D Taffy.
+
 With this plan, the Rust ecosystem gets a first-class, high-performance **3-D layout engine** that feels as natural as `@react-three/flex`, but benefits from Taffy’s speed, compile-time safety, and Bevy’s data-oriented architecture.
 
 [1]: https://github.com/pmndrs/react-three-flex?utm_source=chatgpt.com "pmndrs/react-three-flex: Flexbox for react-three-fiber - GitHub"

--- a/taffy-3d/src/lib.rs
+++ b/taffy-3d/src/lib.rs
@@ -1,0 +1,74 @@
+pub use taffy;
+
+pub mod geometry {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+    pub struct Size3<T> {
+        pub width: T,
+        pub height: T,
+        pub depth: T,
+    }
+
+    impl Size3<f32> {
+        pub const ZERO: Self = Self { width: 0.0, height: 0.0, depth: 0.0 };
+    }
+
+    impl<T> Size3<T> {
+        pub fn map<R, F>(self, f: F) -> Size3<R>
+        where
+            F: Fn(T) -> R,
+        {
+            Size3 { width: f(self.width), height: f(self.height), depth: f(self.depth) }
+        }
+    }
+
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+    pub struct Point3<T> {
+        pub x: T,
+        pub y: T,
+        pub z: T,
+    }
+
+    impl Point3<f32> {
+        pub const ZERO: Self = Self { x: 0.0, y: 0.0, z: 0.0 };
+    }
+
+    impl<T> Point3<T> {
+        pub fn map<R, F>(self, f: F) -> Point3<R>
+        where
+            F: Fn(T) -> R,
+        {
+            Point3 { x: f(self.x), y: f(self.y), z: f(self.z) }
+        }
+    }
+
+    use taffy::geometry::{Point, Size};
+
+    impl<T> From<Size3<T>> for Size<T> {
+        fn from(value: Size3<T>) -> Self {
+            Size { width: value.width, height: value.height }
+        }
+    }
+
+    impl<T: Default> From<Size<T>> for Size3<T> {
+        fn from(value: Size<T>) -> Self {
+            Size3 { width: value.width, height: value.height, depth: T::default() }
+        }
+    }
+
+    impl<T> From<Point3<T>> for Point<T> {
+        fn from(value: Point3<T>) -> Self {
+            Point { x: value.x, y: value.y }
+        }
+    }
+
+    impl<T: Default> From<Point<T>> for Point3<T> {
+        fn from(value: Point<T>) -> Self {
+            Point3 { x: value.x, y: value.y, z: T::default() }
+        }
+    }
+}
+
+pub mod prelude {
+    pub use crate::geometry::{Point3, Size3};
+    pub use taffy::prelude::*;
+}

--- a/taffy-3d/tests/geometry.rs
+++ b/taffy-3d/tests/geometry.rs
@@ -1,0 +1,29 @@
+use taffy_3d::prelude::*;
+
+#[test]
+fn size3_conversions() {
+    let size3 = Size3 { width: 1u32, height: 2u32, depth: 3u32 };
+    let size2: taffy::prelude::Size<u32> = size3.into();
+    assert_eq!(size2.width, 1);
+    assert_eq!(size2.height, 2);
+    let back: Size3<u32> = size2.into();
+    assert_eq!(back, Size3 { width: 1, height: 2, depth: 0 });
+}
+
+#[test]
+fn point3_conversions() {
+    use taffy::geometry::Point;
+
+    let pt3 = Point3 { x: 4i32, y: 5i32, z: 6i32 };
+    let pt2: Point<i32> = pt3.into();
+    assert_eq!(pt2.x, 4);
+    assert_eq!(pt2.y, 5);
+    let back: Point3<i32> = pt2.into();
+    assert_eq!(back, Point3 { x: 4, y: 5, z: 0 });
+}
+
+#[test]
+fn zero_constants() {
+    assert_eq!(Size3::ZERO, Size3 { width: 0.0, height: 0.0, depth: 0.0 });
+    assert_eq!(Point3::ZERO, Point3 { x: 0.0, y: 0.0, z: 0.0 });
+}


### PR DESCRIPTION
## Summary
- add tests for the new `Size3` and `Point3` conversions
- outline remaining parity work in `bootstrap.md`

## Testing
- `cargo test --all-features`
- `cargo check --all-features`


------
https://chatgpt.com/codex/tasks/task_e_6849efe0b8a883229cad1a8c1a86f9b1